### PR TITLE
refactor duplicate script key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,9 +28,9 @@ requirements:
 
 outputs:
   - name: py-lief
-    script:
-      - install-py-lief.sh  # [unix]
-      - install-py-lief.bat  # [win]
+    script: |-
+      install-py-lief.sh  # [unix]
+      install-py-lief.bat  # [win]
     build:
       run_exports:
         - {{ pin_subpackage('py-lief', max_pin='x.x') }}
@@ -80,9 +80,9 @@ outputs:
         - python -c "import ctypes.util, lief; missing = {name for name in {s.name for s in lief.parse(lief._lief.__file__).imported_functions} - {s.name for s in lief.parse(ctypes.util.find_library('LIEF')).exported_functions} if '4LIEF' in name}; assert not missing, missing"
 
   - name: liblief
-    script:
-      - install-liblief.sh  # [unix]
-      - install-liblief.bat  # [win]
+    script: |-
+      install-liblief.sh  # [unix]
+      install-liblief.bat  # [win]
     build:
       run_exports:
         - {{ pin_subpackage('liblief', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: 895ce0321b233a6d610ed89ccbe8dc4aa2cf0bb959919a1db0693ba264f3d29a
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -28,8 +28,9 @@ requirements:
 
 outputs:
   - name: py-lief
-    script: install-py-lief.sh  # [unix]
-    script: install-py-lief.bat  # [win]
+    script:
+      - install-py-lief.sh  # [unix]
+      - install-py-lief.bat  # [win]
     build:
       run_exports:
         - {{ pin_subpackage('py-lief', max_pin='x.x') }}
@@ -79,8 +80,9 @@ outputs:
         - python -c "import ctypes.util, lief; missing = {name for name in {s.name for s in lief.parse(lief._lief.__file__).imported_functions} - {s.name for s in lief.parse(ctypes.util.find_library('LIEF')).exported_functions} if '4LIEF' in name}; assert not missing, missing"
 
   - name: liblief
-    script: install-liblief.sh  # [unix]
-    script: install-liblief.bat  # [win]
+    script:
+      - install-liblief.sh  # [unix]
+      - install-liblief.bat  # [win]
     build:
       run_exports:
         - {{ pin_subpackage('liblief', max_pin='x.x') }}


### PR DESCRIPTION
to fix grayskull parsing, counts as duplicate prior to selectors being applied

https://github.com/regro/cf-scripts/actions/runs/13100011788
```
2025-02-02 15:19:37,590 WARNING  conda_smithy.linter.lints || Error parsing recipe with conda-souschef: DuplicateKeyError('while constructing a mapping',   in "<unicode string>", line 30, column 5:
      - name: py-lief
        ^ (line: 30), 'found duplicate key "script" with value "install-py-lief.bat" (original value: "install-py-lief.sh")',   in "<unicode string>", line 32, column 5:
        script: install-py-lief.bat  # [win]
        ^ (line: 32), '\n                    To suppress this check see:\n                        http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys\n                    ', '                    Duplicate keys will become an error in future releases, and are errors\n                    by default when using the new API.\n                    ')
Traceback (most recent call last):
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/conda_smithy/linter/lints.py", line 1061, in lint_recipe_is_parsable
    Recipe(load_file=recipe_file)
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/souschef/recipe.py", line 35, in __init__
    self._yaml = self.__load_recipe(Path(load_file))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/souschef/recipe.py", line 85, in __load_recipe
    return yaml.load(yaml_file)
           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/main.py", line 451, in load
    return constructor.get_single_data()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 116, in get_single_data
    return self.construct_document(node)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 125, in construct_document
    for _dummy in generator:
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 1482, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 1371, in construct_mapping
    value = self.construct_object(value_node, deep=deep)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 147, in construct_object
    data = self.construct_non_recursive_object(node)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 188, in construct_non_recursive_object
    for _dummy in generator:
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 1475, in construct_yaml_seq
    data.extend(self.construct_rt_sequence(node, data))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 1224, in construct_rt_sequence
    ret_val.append(self.construct_object(child, deep=deep))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 147, in construct_object
    data = self.construct_non_recursive_object(node)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 188, in construct_non_recursive_object
    for _dummy in generator:
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 1482, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 1372, in construct_mapping
    if self.check_mapping_key(node, key_node, maptyp, key, value):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/ruamel/yaml/constructor.py", line 278, in check_mapping_key
    raise DuplicateKeyError(*args)
ruamel.yaml.constructor.DuplicateKeyError: while constructing a mapping
  in "<unicode string>", line 30, column 5:
      - name: py-lief
        ^ (line: 30)
found duplicate key "script" with value "install-py-lief.bat" (original value: "install-py-lief.sh")
  in "<unicode string>", line 32, column 5:
        script: install-py-lief.bat  # [win]
        ^ (line: 32)

To suppress this check see:
    http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
